### PR TITLE
Avoid SQL error if we try to delete shop user

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -5,18 +5,18 @@ on:
     pull_request:
 
 jobs:
-    
+
     security:
-        
+
         name: Security check (PHP ${{ matrix.php }})
-        
+
         runs-on: ubuntu-latest
-        
+
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1']
-        
+                php: ['8.1']
+
         steps:
             - uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ setup_application:
 ${APP_DIR}/docker-compose.yaml:
 	rm -f ${APP_DIR}/docker-compose.yml
 	rm -f ${APP_DIR}/docker-compose.yaml
+	rm -f ${APP_DIR}/compose.yml # Remove Sylius file about Docker
+	rm -f ${APP_DIR}/compose.override.dist.yml # Remove Sylius file about Docker
 	ln -s ../../docker-compose.yaml.dist ${APP_DIR}/docker-compose.yaml
 .PHONY: ${APP_DIR}/docker-compose.yaml
 

--- a/src/Migrations/Version20240730093001.php
+++ b/src/Migrations/Version20240730093001.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Order History plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusOrderHistoryPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240730093001 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event DROP FOREIGN KEY FK_9EA44E026352511C');
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event DROP FOREIGN KEY FK_9EA44E02A45D93BF');
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event ADD CONSTRAINT FK_9EA44E026352511C FOREIGN KEY (admin_user_id) REFERENCES sylius_admin_user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event ADD CONSTRAINT FK_9EA44E02A45D93BF FOREIGN KEY (shop_user_id) REFERENCES sylius_shop_user (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event DROP FOREIGN KEY FK_9EA44E02A45D93BF');
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event DROP FOREIGN KEY FK_9EA44E026352511C');
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event ADD CONSTRAINT FK_9EA44E02A45D93BF FOREIGN KEY (shop_user_id) REFERENCES sylius_shop_user (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+        $this->addSql('ALTER TABLE monsieurbiz_order_history_event ADD CONSTRAINT FK_9EA44E026352511C FOREIGN KEY (admin_user_id) REFERENCES sylius_admin_user (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+    }
+}

--- a/src/Resources/config/doctrine/OrderHistoryEvent.orm.xml
+++ b/src/Resources/config/doctrine/OrderHistoryEvent.orm.xml
@@ -32,11 +32,11 @@
         </field>
 
         <many-to-one field="shopUser" target-entity="Sylius\Component\Core\Model\ShopUserInterface">
-            <join-column name="shop_user_id" />
+            <join-column name="shop_user_id" on-delete="CASCADE" />
         </many-to-one>
 
         <many-to-one field="adminUser" target-entity="Sylius\Component\Core\Model\AdminUserInterface">
-            <join-column name="admin_user_id" />
+            <join-column name="admin_user_id" on-delete="SET NULL" />
         </many-to-one>
 
     </mapped-superclass>


### PR DESCRIPTION
**Before**

When we try to delete a "Shop user" with a cart, and who has been in the checkout and selected an address, for example, we get :

![image](https://github.com/user-attachments/assets/3cebb141-4814-44c5-8f39-b92ce7e4cc55)

Because it has order history lines attached to it

**After**

![image](https://github.com/user-attachments/assets/b6597694-3b64-481d-9909-0f46f22c1455)
