### PR TITLE
Add Sylius 1.13 and PHP 8.3 compatibility

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -6,19 +6,20 @@ on:
     pull_request:
 
 jobs:
-    
+
     recipe:
-        
-        name: Flex recipe (PHP ${{ matrix.php }}, Sylius ${{ matrix.sylius }})
-        
+
         runs-on: ubuntu-latest
-        
+
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.0', '8.1']
-                sylius: [ "~1.11.0", "~1.12.0"]
-        
+                php: ['8.1', '8.2', '8.3']
+                sylius: [ "~1.11.0", "~1.12.0", "~1.13.0"]
+                exclude:
+                    - php: '8.3'
+                      sylius: '~1.11.0'
+
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -26,6 +27,7 @@ jobs:
                   php-version: ${{ matrix.php }}
                   extensions: gd, intl, json
                   ini-values: date.timezone=UTC
+                  tools: symfony-cli
 
             - name: Set project php-version
               run: |
@@ -57,7 +59,7 @@ jobs:
             - name: Create Sylius-Standard project without install
               run: |
                   composer create-project --prefer-dist --no-scripts --no-progress --no-install sylius/sylius-standard sylius "${{ matrix.sylius }}"
-            
+
             # Because the sylius-standard has a soft constraint
             - name: Make sure to install the required version of Sylius
               working-directory: ./sylius

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -8,14 +8,12 @@ jobs:
 
     security:
 
-        name: Security check (PHP ${{ matrix.php }})
-
         runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.1']
+                php: ['8.1', '8.2','8.3']
 
         steps:
             - uses: actions/checkout@v3
@@ -28,7 +26,7 @@ jobs:
 
             - name: Set project php-version
               run: |
-                  echo ${{ matrix.php }} > .php-version
+                  echo "${{ matrix.php }}" > .php-version
 
             - name: Determine composer cache directory
               id: composer-cache-directory
@@ -39,7 +37,7 @@ jobs:
               id: cache-composer
               with:
                   path: ${{ steps.composer-cache-directory.outputs.directory }}
-                  key: composer2-php:${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
+                  key: composer2-php:${{ matrix.php }}-${{ github.sha }}
                   restore-keys: composer2-php:${{ matrix.php }}-
 
             - name: Ensure that composer cache directory exists

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,44 +6,36 @@ on:
     pull_request:
 
 jobs:
-    
+
     php:
-        
-        name: Quality tests (PHP ${{ matrix.php }})
-        
+
         runs-on: ubuntu-latest
-        
+
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.1']
-        
+                php: ['8.1', '8.2', '8.3']
+
         env:
             SYMFONY_ARGS: --no-tls
             COMPOSER_ARGS: --prefer-dist
             DOCKER_INTERACTIVE_ARGS: -t
-        
+
         steps:
-            - uses: actions/checkout@v3
-
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
               with:
-                  node-version: '16'
-
+                  node-version: '14'
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   ini-values: date.timezone=UTC
+                  tools: symfony-cli
 
             - name: Set project php-version
               run: |
-                  echo ${{ matrix.php }} > .php-version
-
-            - name: Install symfony CLI
-              run: |
-                  curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | sudo -E bash
-                  sudo apt install symfony-cli
+                  echo "${{ matrix.php }}" > .php-version
 
             - name: Determine composer cache directory
               id: composer-cache-directory
@@ -54,7 +46,7 @@ jobs:
               id: cache-composer
               with:
                   path: ${{ steps.composer-cache-directory.outputs.directory }}
-                  key: composer2-php:${{ matrix.php }}-${{ hashFiles('**/composer.json') }}
+                  key: composer2-php:${{ matrix.php }}-${{ github.sha }}
                   restore-keys: composer2-php:${{ matrix.php }}-
 
             - name: Ensure that composer cache directory exists

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .DEFAULT_GOAL := help
 SHELL=/bin/bash
 APP_DIR=tests/Application
-SYLIUS_VERSION=1.12.0
+SYLIUS_VERSION=1.13.0
 SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console
 export COMPOSE_PROJECT_NAME=order-history
 PLUGIN_NAME=sylius-${COMPOSE_PROJECT_NAME}-plugin
-COMPOSE=docker-compose
+COMPOSE=docker compose
 YARN=yarn
 DOCTRINE_MIGRATIONS_NAMESPACE=MonsieurBiz\SyliusOrderHistoryPlugin\Migrations
 
@@ -131,7 +131,7 @@ test.container: ## Lint the symfony container
 	${CONSOLE} lint:container
 
 test.yaml: ## Lint the symfony Yaml files
-	${CONSOLE} lint:yaml ../../recipes ../../src/Resources/config
+	${CONSOLE} lint:yaml ../../src/Resources/config --parse-tags
 
 test.schema: ## Validate MySQL Schema
 	${CONSOLE} doctrine:schema:validate

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ machine events.
 
 ![Demo of the Order History](docs/images/demo.png)
 
+## Compatibility
+
+| Sylius Version | PHP Version |
+|---|---|
+
+| 1.11 | 8.1 - 8.2 |
+| 1.12 | 8.1 - 8.3 |
+| 1.13 | 8.1 - 8.3 |
+
 ## Installation
 
 Install the plugin via composer:

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "Add a timeline with all the order events on back-office.",
     "license": "MIT",
     "require": {
-        "php": "~8.0",
-        "sylius/sylius": ">=1.9 <1.13",
+        "php": "~8.1",
+        "sylius/sylius": ">=1.11 <1.14",
         "beberlei/doctrineextensions": "^1.3"
     },
     "prefer-stable": true,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,3 @@ parameters:
 
         # Test dependencies
         - 'tests/Application/**/*'
-
-    ignoreErrors:
-        - '#^Method MonsieurBiz\\SyliusOrderHistoryPlugin\\Repository\\OrderHistoryEventRepository\:\:getByOrderId\(\) should return array but returns mixed\.$#'


### PR DESCRIPTION
## Sylius 1.13 compatibility

closes #71

### Compatibility

| Sylius Version | PHP Version |
|---|---|
| 1.11 | 8.1 - 8.2 |
| 1.12 | 8.1 - 8.3 |
| 1.13 | 8.1 - 8.3 |

## Screenshot

![image](https://github.com/user-attachments/assets/57238c83-3d52-47c2-8eaa-3020b83eb9e6)
